### PR TITLE
Bugfix: repeated MSER features

### DIFF
--- a/+localFeatures/VlFeatMser.m
+++ b/+localFeatures/VlFeatMser.m
@@ -39,10 +39,9 @@ classdef VlFeatMser < localFeatures.GenericLocalFeatureExtractor & ...
       if(size(img,3)>1), img = rgb2gray(img); end
       img = im2uint8(img); % If not already in uint8, then convert
 
-      [xx brightOnDarkFrames] = vl_mser(img,obj.vlMserArguments{:});
-      [xx darkOnBrightFrames] = vl_mser(255-img,obj.vlMserArguments{:});
-
-      frames = vl_ertr([brightOnDarkFrames darkOnBrightFrames]);
+      % vl_mser() computes both bright on dark and dark on bright frames by default
+      [xx frames] = vl_mser(img,obj.vlMserArguments{:});
+      frames = vl_ertr(frames);
       sel = frames(3,:).*frames(5,:) - frames(4,:).^2 >= 1 ;
       frames = frames(:, sel) ;
       timeElapsed = toc(startTime);


### PR DESCRIPTION
`localFeatures.VlFeatMser` was manually extracting bright on dark and dark
on bright MSER features by calling `vl_mser()` twice. However, `vl_mser()`
extracts both types of features by default, causing
`localFeatures.VlFeatMser.extractFeatures()` to always return two copies
of the same feature.
